### PR TITLE
branch Paulskpt - mods to CMakesLists. and 2 .pio files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,5 +73,9 @@ pico_generate_pio_header(${name} ${CMAKE_CURRENT_SOURCE_DIR}/src/lan8720_tx.pio)
 target_link_libraries(pico_lwip INTERFACE pico_stdlib hardware_sync)
 target_link_libraries(${name} pico_stdlib pico_mem_ops pico_unique_id hardware_sync pico_sync_mutex hardware_pio hardware_dma hardware_irq hardware_spi hardware_adc hardware_uart pico_lwip)
 
+# enable usb output, disable uart output
+pico_enable_stdio_usb(${name} 1)
+pico_enable_stdio_uart(${name} 0)
+
 pico_add_extra_outputs(${name})
 

--- a/src/lan8720_rx.pio
+++ b/src/lan8720_rx.pio
@@ -9,14 +9,14 @@
   wait 0 pin 2       ; Wait while TX0, TX1 and TXEN are nonzero
   wait 0 pin 0       ;
   wait 0 pin 1       ;
-                      
+  
   wait 1 pin 2       ; Detect preamble
   wait 1 pin 0       ;
-
+  
   wait 1 pin 1       ; Detect start frame delimiter
-
+  
   wait 0 gpio 22     ; Wait single clock
-  wait 1 gpio 22     ; 
+  wait 1 gpio 22     ;
 
 recvloop:
   wait 0 gpio 22     ; wait for clock LO

--- a/src/lan8720_tx.pio
+++ b/src/lan8720_tx.pio
@@ -13,8 +13,8 @@ idle:
                                 ; this loops while TXEN is inactive
   jmp !osre inittx    side 0x00 ; if there are data in output shift register, go to inittx
   jmp idle            side 0x00 ; repeat
-
-inittx:
+  
+  inittx:
                                 ; wait single clock
   wait 1 gpio 22      side 0x00 ; wait for clock HI
   wait 0 gpio 22      side 0x00 ; wait for clock LO


### PR DESCRIPTION
See: CMakeLists.txt. Added 2 lines. One for USB, the 2nd for UART. USB ON, UART OFF.
In the src/lan8720_rx.pio and src/lan8720_tx.pio - due to build errors: problems with line-endings, changed CRLF sequences to LF, only in the reported lines (a few).
But the Git app on my MS Windows PC gives a warning that LF will be changed into CRLF ! Anyway, my modified repo clone builds now OK.